### PR TITLE
build: move to Alpine 3.11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,6 @@
 
 edgeXBuildCApp (
     project: 'device-bacnet-c',
-    dockerBuildFilePath: 'scripts/Dockerfile.alpine-3.9-base',
-    dockerFilePath: 'scripts/Dockerfile.alpine-3.9'
+    dockerBuildFilePath: 'scripts/Dockerfile.alpine-3.11-base',
+    dockerFilePath: 'scripts/Dockerfile.alpine-3.11'
 )

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ docker: $(DOCKERS)
 
 docker_device_bacnet_c:
 	    docker build \
-	        -f scripts/Dockerfile.alpine-3.9 \
+	        -f scripts/Dockerfile.alpine-3.11 \
 	        --label "git_sha=$(GIT_SHA)" \
 	        -t edgexfoundry/docker-device-bacnet-c:${GIT_SHA} \
 	        -t edgexfoundry/docker-device-bacnet-c:${VERSION}-dev \

--- a/docs/containerisation.txt
+++ b/docs/containerisation.txt
@@ -1,11 +1,11 @@
 Containerisation of the BACnet device service.
 
 The BACnet device service can be build in a docker container. A Docker file is
-provided in the scripts/ directory using Alpine Linux 3.9 as the base image. To build an
+provided in the scripts/ directory using Alpine Linux 3.11 as the base image. To build an
 image using this Docker file, change directory to the base directory of the
 device service and execute the following command:
 
-$ docker build --no-cache --tag bacnet-device-service --file ./scripts/Dockerfile.alpine-3.9 .
+$ docker build --no-cache --tag bacnet-device-service --file ./scripts/Dockerfile.alpine-3.11 .
 
 This will build the device service image containing both the BACnet/IP and
 BACnet/MSTP device services.

--- a/scripts/Dockerfile.alpine-3.11
+++ b/scripts/Dockerfile.alpine-3.11
@@ -1,4 +1,4 @@
-ARG BASE=alpine:3.9
+ARG BASE=alpine:3.11
 FROM ${BASE} as builder
 RUN apk add --update --no-cache build-base git gcc cmake make linux-headers yaml-dev libmicrohttpd-dev curl-dev util-linux-dev ncurses-dev
 
@@ -12,7 +12,7 @@ RUN /device-bacnet-c/scripts/build_deps.sh
 
 RUN /device-bacnet-c/scripts/build.sh 
 
-FROM alpine:3.9
+FROM alpine:3.11
 MAINTAINER iotech <support@iotechsys.com>
 RUN apk add --update --no-cache linux-headers yaml libmicrohttpd curl libuuid
 
@@ -30,6 +30,6 @@ COPY res /res
 COPY profiles /profiles
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
-      copyright='Copyright (c) 2019: IoTech Ltd'
+      copyright='Copyright (c) 2019-2020: IoTech Ltd'
 
 ENTRYPOINT ["/startup.sh"]

--- a/scripts/Dockerfile.alpine-3.11-base
+++ b/scripts/Dockerfile.alpine-3.11-base
@@ -1,4 +1,4 @@
-ARG BASE=alpine:3.9
+ARG BASE=alpine:3.11
 FROM ${BASE}
 RUN apk add --update --no-cache build-base git gcc cmake make linux-headers yaml-dev libmicrohttpd-dev curl-dev util-linux-dev ncurses-dev
 
@@ -10,4 +10,4 @@ WORKDIR /device-bacnet-c
 
 RUN /device-bacnet-c/scripts/build_deps.sh
 
-RUN /device-bacnet-c/scripts/build.sh 
+RUN /device-bacnet-c/scripts/build.sh

--- a/scripts/build_deps.sh
+++ b/scripts/build_deps.sh
@@ -9,8 +9,7 @@ then
   cd /device-bacnet-c/deps
 
   # install libcbor used for building the SDK
-  git clone https://github.com/PJK/libcbor
-  sed -e 's/-flto//' -i libcbor/CMakeLists.txt
+  git clone --branch v0.7.0 https://github.com/PJK/libcbor
   cd libcbor
   cmake -DCMAKE_BUILD_TYPE=Release -DCBOR_CUSTOM_ALLOC=ON -DCMAKE_INSTALL_LIBDIR=lib .
   make


### PR DESCRIPTION
Signed-off-by: Iain Anderson <iain@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Container build uses Alpine Linux 3.9 and the latest committed libcbor


## What is the new behavior?
Move to newer Alpine version 3.11 in line with the SDK and other services
Pin libcbor to v0.7.0

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information