### PR TITLE
fix: remove legacy logging options (#51)

### DIFF
--- a/res/ip/configuration.toml
+++ b/res/ip/configuration.toml
@@ -30,9 +30,6 @@
   ProfilesDir = '/profiles'
   SendReadingsOnChanged = true
 
-[Logging]
-  File = '-'
-
 [Driver]
 #  BBMD_ADDRESS = "10.100.22.243"
 #  BBMD_PORT = "47809"

--- a/res/mstp/configuration.toml
+++ b/res/mstp/configuration.toml
@@ -30,8 +30,5 @@
   ProfilesDir = '/profiles'
   SendReadingsOnChanged = true
 
-[Logging]
-  File = '-'
-
 [Driver]
   DefaultDevicePath = '/dev/ttyUSB0'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-bacnet-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Supplied configuration files contain log filename option which is no longer supported

## Issue Number: #51 


## What is the new behavior?
Removed legacy configuration element

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
