### PR TITLE
ci: update local docker image names in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ docker_device_bacnet_c:
 	    docker build \
 	        -f scripts/Dockerfile.alpine \
 	        --label "git_sha=$(GIT_SHA)" \
-	        -t edgexfoundry/docker-device-bacnet-c:${GIT_SHA} \
-	        -t edgexfoundry/docker-device-bacnet-c:${VERSION}-dev \
+	        -t edgexfoundry/device-bacnet:${GIT_SHA} \
+	        -t edgexfoundry/device-bacnet:${VERSION}-dev \
             .


### PR DESCRIPTION
As part of the Ireland release it was decided to remove the docker- in the image prefix and -go in the image suffix.