### PR TITLE
fix: use new port assignments (#57)

### DIFF
--- a/docs/containerisation.txt
+++ b/docs/containerisation.txt
@@ -13,12 +13,12 @@ BACnet/MSTP device services.
 Having built the docker image, a docker container can now be run. To run the
 BACnet/IP device service execute the following command:
 
-$ docker run --name bacnet-device-service --network=edgex_foundry_edgex-network -p 49980:49980 bacnet-device-service ip
+$ docker run --name bacnet-device-service --network=edgex_foundry_edgex-network -p 59980:59980 bacnet-device-service ip
 
 The docker run command specifies the port to expose from the container. This
 should be the same as in the TOML configuration file. The standard for the 
-BACnet/IP device service is 49980, and the standard for the BACnet/MSTP device
-service is 49981. The image also takes a parameter to select whether the
+BACnet/IP device service is 59980, and the standard for the BACnet/MSTP device
+service is 59981. The image also takes a parameter to select whether the
 BACnet/IP or BACnet/MSTP device service should be run.
 
 When running the BACnet/IP device service in a container, it will need to
@@ -31,7 +31,7 @@ device path to be made available to the container. To do this, the --device
 parameter needs to be set for the docker run command. An example of this can be
 seen in the following command:
 
-docker run --name bacnet-device-service --network=edgex_foundry_edgex-network -p 49981:49981 --device=/dev/ttyUSB0 bacnet-device-service mstp
+docker run --name bacnet-device-service --network=edgex_foundry_edgex-network -p 59981:59981 --device=/dev/ttyUSB0 bacnet-device-service mstp
 
 The device specified in the "--device" argument should be the same as set up in
 the [Driver] section of the TOML configuration located in the res/mstp
@@ -43,4 +43,4 @@ choice, remember to expose the appropriate ports for both services and the
 device for the BACnet/MSTP device service. This can be seen in the following
 command:
 
-docker run --name bacnet-device-service --network=edgex_foundry_edgex-network -p 49980:49980 -p 49981:49981 --device=/dev/ttyUSB0 bacnet-device-service
+docker run --name bacnet-device-service --network=edgex_foundry_edgex-network -p 59980:59980 -p 59981:59981 --device=/dev/ttyUSB0 bacnet-device-service

--- a/res/ip/configuration.toml
+++ b/res/ip/configuration.toml
@@ -1,6 +1,6 @@
 [Service]
   ServerBindAddr = '0.0.0.0'
-  Port = 49980
+  Port = 59980
   ConnectRetries = 3
   HealthCheck = ''
   Labels = [ 'BACnet' ]
@@ -12,11 +12,11 @@
 [Clients]
   [Clients.Data]
     Host = 'edgex-core-data'
-    Port = 48080
+    Port = 59880
 
   [Clients.Metadata]
     Host = 'edgex-core-metadata'
-    Port = 48081
+    Port = 59881
 
 [Device]
   DataTransform = true

--- a/res/mstp/configuration.toml
+++ b/res/mstp/configuration.toml
@@ -1,6 +1,6 @@
 [Service]
   ServerBindAddr = '0.0.0.0'
-  Port = 49981
+  Port = 59981
   ConnectRetries = 3
   HealthCheck = ''
   Labels = [ 'BACnet' ]
@@ -12,11 +12,11 @@
 [Clients]
   [Clients.Data]
     Host = 'edgex-core-data'
-    Port = 48080
+    Port = 59880
 
   [Clients.Metadata]
     Host = 'edgex-core-metadata'
-    Port = 48081
+    Port = 59881
 
 [Device]
   DataTransform = true


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-bacnet-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Service uses old port assignments

## Issue Number: #57 


## What is the new behavior?
New port assignments (59xxx) configured

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No
Clients using old port ranges will need to be reconfigured
## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
