### PR TITLE
docs: update build procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ the current directory is the BACnet device service directory
 the command below into the command line to run the build
 script.
 
-	./scripts/build.sh
+	make build
 
 This will build two device services: device-bacnet-ip and
 device-bacnet-mstp. To only build one of them, run the


### PR DESCRIPTION
closes: #94

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-bacnet-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

- clone device-bacnet-c, export the preferred C SDK
- `cd device-bacnet-c`, do `make build`.
- This will eliminate the error faced in #94 

Successful build
```bash
[ 88%] Building C object CMakeFiles/device-bacnet-c.dir/return_data.c.o
[100%] Linking C executable device-bacnet-c
make[3]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
[100%] Built target device-bacnet-c
...
...
[ 88%] Building C object CMakeFiles/device-bacnet-c.dir/return_data.c.o
[100%] Linking C executable device-bacnet-c
make[3]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
[100%] Built target device-bacnet-c
```
---
Thanks