### PR TITLE
refactor(bacnet-c): fix incorrect format specifier in printf

### DIFF
--- a/src/c/driver.c
+++ b/src/c/driver.c
@@ -569,7 +569,7 @@ write_access_data_populate (BACNET_WRITE_ACCESS_DATA **head, uint32_t nvalues,
         break;
       default:
         iot_log_error (driver->lc,
-                       "The value type %d is not accepted", values[i]);
+                       "The value type %d is not accepted", iot_data_type(values[i]));
         write_access_data_free (*head);
         return false;
     }

--- a/src/c/driver.c
+++ b/src/c/driver.c
@@ -569,7 +569,7 @@ write_access_data_populate (BACNET_WRITE_ACCESS_DATA **head, uint32_t nvalues,
         break;
       default:
         iot_log_error (driver->lc,
-                       "The value type %d is not accepted", iot_data_type(values[i]));
+                       "The value type %s is not accepted", iot_data_type_name(values[i]));
         write_access_data_free (*head);
         return false;
     }


### PR DESCRIPTION
closes:#98

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-bacnet-c/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-bacnet-c/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
- Clone the repository with included changes.
- Run make build
- build finished successfully without warnings.

```bash
~/edgex-foundry/device-bacnet-c$ make build
scripts/build.sh
+ readlink -f scripts/build.sh
+ dirname /home/mpunix/edgex-foundry/device-bacnet-c/scripts/build.sh
+ dirname /home/mpunix/edgex-foundry/device-bacnet-c/scripts
+ ROOT=/home/mpunix/edgex-foundry/device-bacnet-c
+ echo /home/mpunix/edgex-foundry/device-bacnet-c
/home/mpunix/edgex-foundry/device-bacnet-c
+ cd /home/mpunix/edgex-foundry/device-bacnet-c
+ [ ! -f /home/mpunix/edgex-foundry/device-bacnet-c/lib/ip/libbacnet.a ]
+ [ ! -f /home/mpunix/edgex-foundry/device-bacnet-c/lib/mstp/libbacnet.a ]
+ mkdir -p /home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip
+ cd /home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip
+ cmake -DDATALINK:STRING=BACDL_BIP=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release /home/mpunix/edgex-foundry/device-bacnet-c/src/c
-- Found IOT: /opt/iotech/iot/1.5/lib/libiot.so
-- /opt/iotech/iot/1.5/include
-- Configuring done
-- Generating done
-- Build files have been written to: /home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip
+ make
+ tee release.log
make[1]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
make[2]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
make[3]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
make[3]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
make[3]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
[ 11%] Building C object CMakeFiles/bacnet_objects.dir/home/mpunix/edgex-foundry/device-bacnet-c/bacnet-stack/demo/object/device-client.c.o
[ 22%] Linking C static library libbacnet_objects.a
make[3]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
[ 22%] Built target bacnet_objects
make[3]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
make[3]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
make[3]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
[ 33%] Building C object CMakeFiles/device-bacnet-c.dir/main.c.o
[ 44%] Building C object CMakeFiles/device-bacnet-c.dir/address_entry.c.o
[ 55%] Building C object CMakeFiles/device-bacnet-c.dir/address_instance_map.c.o
[ 66%] Building C object CMakeFiles/device-bacnet-c.dir/device_condition_map.c.o
[ 77%] Building C object CMakeFiles/device-bacnet-c.dir/driver.c.o
[ 88%] Building C object CMakeFiles/device-bacnet-c.dir/return_data.c.o
[100%] Linking C executable device-bacnet-c
make[3]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
[100%] Built target device-bacnet-c
make[2]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
make[1]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-ip'
+ mkdir -p /home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp
+ cd /home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp
+ cmake -DDATALINK:STRING=BACDL_MSTP=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release /home/mpunix/edgex-foundry/device-bacnet-c/src/c
-- The C compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Found IOT: /opt/iotech/iot/1.5/lib/libiot.so
-- /opt/iotech/iot/1.5/include
-- Configuring done
-- Generating done
-- Build files have been written to: /home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp
+ make
+ tee release.log
make[1]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
make[2]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
make[3]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
make[3]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
make[3]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
[ 11%] Building C object CMakeFiles/bacnet_objects.dir/home/mpunix/edgex-foundry/device-bacnet-c/bacnet-stack/demo/object/device-client.c.o
[ 22%] Linking C static library libbacnet_objects.a
make[3]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
[ 22%] Built target bacnet_objects
make[3]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
make[3]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
make[3]: Entering directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
[ 33%] Building C object CMakeFiles/device-bacnet-c.dir/main.c.o
[ 44%] Building C object CMakeFiles/device-bacnet-c.dir/address_entry.c.o
[ 55%] Building C object CMakeFiles/device-bacnet-c.dir/address_instance_map.c.o
[ 66%] Building C object CMakeFiles/device-bacnet-c.dir/device_condition_map.c.o
[ 77%] Building C object CMakeFiles/device-bacnet-c.dir/driver.c.o
[ 88%] Building C object CMakeFiles/device-bacnet-c.dir/return_data.c.o
[100%] Linking C executable device-bacnet-c
make[3]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
[100%] Built target device-bacnet-c
make[2]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
make[1]: Leaving directory '/home/mpunix/edgex-foundry/device-bacnet-c/build/release/device-bacnet-mstp'
```