### PR TITLE
fix: bundle the matching libcbor runtime

### DIFF
--- a/scripts/Dockerfile.alpine
+++ b/scripts/Dockerfile.alpine
@@ -35,12 +35,13 @@ MAINTAINER iotech <support@iotechsys.com>
 RUN wget https://iotech.jfrog.io/artifactory/api/security/keypair/public/repositories/alpine-release -O /etc/apk/keys/alpine.dev.rsa.pub
 RUN echo 'https://iotech.jfrog.io/artifactory/alpine-release/v3.20/main' >> /etc/apk/repositories
 
-RUN apk add --update --no-cache linux-headers yaml libmicrohttpd curl libuuid iotech-paho-mqtt-c-dev-1.3 hiredis libcbor iotech-iot-1.6 dumb-init
+RUN apk add --update --no-cache linux-headers yaml libmicrohttpd curl libuuid iotech-paho-mqtt-c-dev-1.3 hiredis iotech-iot-1.6 dumb-init
 # Ensure using latest versions of all installed packages to avoid any recent CVEs
 RUN apk --no-cache upgrade
 
 COPY --from=builder /device-bacnet-c/build/release/ /
 COPY --from=builder /usr/lib/libcsdk.so /usr/lib
+COPY --from=builder /usr/lib/libcbor.so* /usr/lib/
 COPY --from=builder /usr/share/doc/edgex-csdk /usr/share/doc/edgex-csdk
 
 COPY LICENSE /.


### PR DESCRIPTION
Fixes #114.

The runtime stage installed libcbor independently from the builder stage. If
those package layers were refreshed at different times, `libcsdk.so` could be
linked against one libcbor SONAME while the final image shipped another.

This copies the builder's libcbor runtime alongside `libcsdk.so`, keeping the
linked and shipped versions together.

## PR Checklist

- [x] I am not introducing a breaking change
- [x] I am not introducing a new dependency
- [ ] I have added unit tests for the new feature or bug fix
  - Not applicable; this is a container image linkage fix.
- [x] I have fully tested the bug fix
- [ ] I have opened a PR for the related docs change
  - Not applicable; no user-facing behavior or configuration changes.

## Testing Instructions

- Reproduced the published 4.0.2 image mismatch: `libcsdk.so` requires
  `libcbor.so.0.10`, while the image contains only `libcbor.so.0.11`.
- Built the updated Alpine image from scratch with `--no-cache`.
- Verified the final executable resolves every dynamic library with `ldd`.
- Verified `libcsdk.so` requires `libcbor.so.0.11` and the final image contains
  that SONAME.
- Verified the builder and runtime copies of libcbor have identical SHA-256
  hashes.

## New Dependency Instructions

Not applicable.
