### PR TITLE
fix: handle ENUMERATED application tag when reading property values

### DIFF
--- a/src/c/driver.c
+++ b/src/c/driver.c
@@ -483,6 +483,9 @@ void devsdk_commandresult_populate (devsdk_commandresult *readings,
       case BACNET_APPLICATION_TAG_DOUBLE:
         readings[i].value = iot_data_alloc_f64 (deviceReading->type.Double);
         break;
+      case BACNET_APPLICATION_TAG_ENUMERATED:
+        readings[i].value = iot_data_alloc_ui32 (deviceReading->type.Enumerated);
+        break;
       default:
         break;
     }


### PR DESCRIPTION
Present_Value of Binary Input, Binary Output and Binary Value objects is of type
BACnetBinaryPV (`ENUMERATED { inactive (0), active (1) }`) per ASHRAE 135. The
bundled BACnet stack encodes and decodes it accordingly — `demo/object/bi.c`,
`bo.c` and `bv.c` use `encode_application_enumerated()` for PROP_PRESENT_VALUE,
and `include/bacenum.h` defines `BACNET_BINARY_PV`.

However `devsdk_commandresult_populate()` has no case for
`BACNET_APPLICATION_TAG_ENUMERATED`, so the reading value is left NULL and passed
on to the SDK. Reading any binary resource terminates the service with SIGSEGV and
produces no log output, which matches the report in #91. This is also consistent
with the README's "Limitations" note that Enum types are not supported.

Note: the resource is declared as `Bool` in the profile but the reading comes back
as `Uint32`. Mapping ENUMERATED to a single fixed type cannot satisfy both binary
objects (BACnetBinaryPV) and other enumerated properties. An alternative would be
to map based on the BACnet object type (binary-* → Bool, otherwise → Uint32), but
`devsdk_commandresult_populate()` does not currently receive the object type. I'm
happy to change the approach — which would you prefer?

## PR Checklist

- [x] I am not introducing a breaking change
- [x] I am not introducing a new dependency
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
      → the repository has no unit test framework; verified manually, see below
- [x] I have fully tested (add details below) this the new feature or bug fix
- [ ] I have opened a PR for the related docs change (if not, why?)
      → no documented behaviour changes; the README "Limitations" section could be
        updated once the type mapping question above is settled

## Testing Instructions

Reproduced against Shizuku2 (an open-source BACnet/IP VRF simulator), device
instance 2 on port 47810, with the device service and the simulator both on the
host network.

Minimal device profile with two resources and no autoEvents:

| resource   | attributes                      | valueType |
|------------|-------------------------------------------------------------|-----------|
| AnalogRead | type: analog-input, instance:ue | Float32   |
| BinaryRead | type: binary-input, instance: 1102, property: present-value | Bool      |

Before this change (main @ 652c4c7):

    GET /api/v3/device/name/repro-vrf/AnalogRead  -> 200, value 0.00000000e+00
    GET /api/v3/device/name/repro-vrf/Binary
                                                     process exits with 139 (SIGSEGV),


After this change:

    GET /api/v3/device/name/repro-vrf/Analog00e+00
    GET /api/v3/device/name/repro-vrf/BinaryRead  -> 200, value 0

## New Dependency Instructions (If applicable)

n/a